### PR TITLE
Restrict debug remotes to authorized developers

### DIFF
--- a/places/game/src/ServerScriptService/DebugRemotes.server.lua
+++ b/places/game/src/ServerScriptService/DebugRemotes.server.lua
@@ -4,21 +4,42 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Maid = require(ReplicatedStorage.Modules.combinedFunctions.Maid)
 
+local ALLOWED_USER_IDS: {[number]: boolean} = {
+	[1649598894] = true,
+	[1021056267] = true,
+	[3454147180] = true,
+}
+
+local ALLOWED_ROLES: {[string]: boolean} = {
+	Developer = true,
+}
+
+local function isAuthorized(player: Player): boolean
+	if ALLOWED_USER_IDS[player.UserId] then
+	        return true
+	end
+	local role = player:GetAttribute("Role")
+	if role and ALLOWED_ROLES[role] then
+	        return true
+	end
+	return false
+end
+
 local DEBUG_FLAGS_FOLDER = "DebugFlags"
 local DEBUG_EVENTS_FOLDER = "DebugEvents"
 
 local flagsFolder = ReplicatedStorage:FindFirstChild(DEBUG_FLAGS_FOLDER)
 if not flagsFolder then
-        flagsFolder = Instance.new("Folder")
-        flagsFolder.Name = DEBUG_FLAGS_FOLDER
-        flagsFolder.Parent = ReplicatedStorage
+	flagsFolder = Instance.new("Folder")
+	flagsFolder.Name = DEBUG_FLAGS_FOLDER
+	flagsFolder.Parent = ReplicatedStorage
 end
 
 local eventsFolder = ReplicatedStorage:FindFirstChild(DEBUG_EVENTS_FOLDER)
 if not eventsFolder then
-        eventsFolder = Instance.new("Folder")
-        eventsFolder.Name = DEBUG_EVENTS_FOLDER
-        eventsFolder.Parent = ReplicatedStorage
+	eventsFolder = Instance.new("Folder")
+	eventsFolder.Name = DEBUG_EVENTS_FOLDER
+	eventsFolder.Parent = ReplicatedStorage
 end
 
 local flagMaids = {}
@@ -40,50 +61,56 @@ ensureRemote("MonsterDebugEvent")
 local debugToggleEvent = ensureRemote("DebugToggleEvent")
 
 local function toFlagName(key: string)
-        local flagName = key:gsub("_(%w)", function(s)
-                return s:upper()
-        end)
-        return flagName:sub(1,1):upper() .. flagName:sub(2)
+	local flagName = key:gsub("_(%w)", function(s)
+	        return s:upper()
+	end)
+	return flagName:sub(1,1):upper() .. flagName:sub(2)
 end
 
 local function updateFlag(key: string, enabled: boolean)
-        local flagName = toFlagName(key)
+	local flagName = toFlagName(key)
 
-        local flag = flagsFolder:FindFirstChild(flagName)
-        if not flag then
-                flag = Instance.new("BoolValue")
-                flag.Name = flagName
-                flag.Parent = flagsFolder
-        end
-        flag.Value = enabled
+	local flag = flagsFolder:FindFirstChild(flagName)
+	if not flag then
+	        flag = Instance.new("BoolValue")
+	        flag.Name = flagName
+	        flag.Parent = flagsFolder
+	end
+	flag.Value = enabled
 
-        local event = eventsFolder:FindFirstChild(flagName)
-        if not event then
-                event = Instance.new("BindableEvent")
-                event.Name = flagName
-                event.Parent = eventsFolder
-        end
-        event:Fire(enabled)
+	local event = eventsFolder:FindFirstChild(flagName)
+	if not event then
+	        event = Instance.new("BindableEvent")
+	        event.Name = flagName
+	        event.Parent = eventsFolder
+	end
+	event:Fire(enabled)
 
-        local maid = flagMaids[flagName]
-        if maid then
-                maid:EndAllTasks()
-        else
-                maid = Maid.new()
-                flagMaids[flagName] = maid
-        end
-        maid:GiveSignal(flag.Changed, function(value)
-                event:Fire(value)
-        end)
+	local maid = flagMaids[flagName]
+	if maid then
+	        maid:EndAllTasks()
+	else
+	        maid = Maid.new()
+	        flagMaids[flagName] = maid
+	end
+	maid:GiveSignal(flag.Changed, function(value)
+	        event:Fire(value)
+	end)
 end
 
-debugToggleEvent.OnServerEvent:Connect(function(_player, key, enabled)
+debugToggleEvent.OnServerEvent:Connect(function(player, key, enabled)
+        if not isAuthorized(player) then
+                return
+        end
         updateFlag(tostring(key), not not enabled)
 end)
 
 -- Example: forward MonsterDebugEvent to your AI system
 local monsterEvent = ensureRemote("MonsterDebugEvent")
 monsterEvent.OnServerEvent:Connect(function(player, enabled)
+        if not isAuthorized(player) then
+                return
+        end
         print(("[MonsterDebug] %s set VisionCones = %s"):format(player.Name, tostring(enabled)))
         -- TODO: forward to your monster system (BindableEvent, module, etc.)
 end)

--- a/places/game/src/StarterPlayer/StarterPlayerScripts/DebugMenu.client.lua
+++ b/places/game/src/StarterPlayer/StarterPlayerScripts/DebugMenu.client.lua
@@ -8,6 +8,32 @@ local UserInputService = game:GetService("UserInputService")
 local RunService = game:GetService("RunService")
 
 local localPlayer = Players.LocalPlayer
+
+local ALLOWED_USER_IDS: {[number]: boolean} = {
+	[1649598894] = true,
+	[1021056267] = true,
+	[3454147180] = true,
+}
+
+local ALLOWED_ROLES: {[string]: boolean} = {
+	Developer = true,
+}
+
+local function isAuthorized(player: Player): boolean
+	if ALLOWED_USER_IDS[player.UserId] then
+	        return true
+	end
+	local role = player:GetAttribute("Role")
+	if role and ALLOWED_ROLES[role] then
+	        return true
+	end
+	return false
+end
+
+if not isAuthorized(localPlayer) then
+	return
+end
+
 local playerGui = localPlayer:WaitForChild("PlayerGui")
 
 ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- validate user IDs or role attributes before toggling debug flags or monster events
- only load the DebugMenu UI for authorized developers

## Testing
- `rojo build places/game -o game.rbxlx` *(fails: command not found: rojo)*

------
https://chatgpt.com/codex/tasks/task_e_68bba4147af08333aa404e76a3ce39ac