### PR TITLE
refactor: use RunService heartbeat for monster loop

### DIFF
--- a/places/game/src/ServerScriptService/MonsterAI.server.lua
+++ b/places/game/src/ServerScriptService/MonsterAI.server.lua
@@ -383,7 +383,7 @@ local function setupMonsterAI(monsterModel)
                     updateVisionConeColor(monsterModel, false)
                 end
             end
-            wait(0.12)
+            RunService.Heartbeat:Wait()
         end
     end)()
 end


### PR DESCRIPTION
## Summary
- replace `wait(0.12)` with `RunService.Heartbeat:Wait()` for consistent Monster AI loop timing

## Testing
- `lune run places/game/src/ServerScriptService/Tests/TestUtils.spec.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbbd9058dc8333ab1c5738f9163b10