### PR TITLE
Replace tick with os.clock in MonsterAI

### DIFF
--- a/places/game/src/ServerScriptService/MonsterAI.server.lua
+++ b/places/game/src/ServerScriptService/MonsterAI.server.lua
@@ -259,7 +259,7 @@ local function chaseAndAttack(monster, target)
         if primary then
             local dist = (primary.Position - target.HumanoidRootPart.Position).Magnitude
             if dist < 4 then
-                local now = tick()
+                local now = os.clock()
                 if not MonsterAttackCooldown[monster] or now - MonsterAttackCooldown[monster] > 1.5 then
                     MonsterAttackCooldown[monster] = now
                     local targetHum = target:FindFirstChildOfClass("Humanoid")
@@ -325,7 +325,7 @@ local function setupMonsterAI(monsterModel)
 
     coroutine.wrap(function()
         while monsterModel.Parent do
-            local now = tick()
+            local now = os.clock()
             local seenPlayer = nil
             for _, player in ipairs(Players:GetPlayers()) do
                 local char = player.Character


### PR DESCRIPTION
## Summary
- replace deprecated `tick()` with `os.clock()` in `MonsterAI.server.lua`

## Testing
- `rojo build places/game/default.project.json` *(fails: command not found)*
- `lune test places/game/src/ServerScriptService/Tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbbe4881d483338f67f014ce3b5c85