### PR TITLE
Add player collider debug visualizer

### DIFF
--- a/places/game/src/StarterPlayer/StarterPlayerScripts/DebugMenu.client.lua
+++ b/places/game/src/StarterPlayer/StarterPlayerScripts/DebugMenu.client.lua
@@ -97,10 +97,11 @@ local HOTKEY_TOGGLE_MENU = Enum.KeyCode.F3
 -- type="direct": fires a specific RemoteEvent by name (e.g., MonsterDebugEvent)
 -- type="remote": fires DebugToggleEvent with a 'key'
 local TOGGLES = {
-	{ section="Monsters", label="Vision Cones", type="direct", remoteName="MonsterDebugEvent", default=false, tooltip="Show/hide monster vision cones." },
-	{ section="Elevator", label="Show Sensors", type="remote", key="elevator_sensors",       default=false, tooltip="Paint doorway & cabin sensors (server-side)." },
-	{ section="Elevator", label="Music",         type="remote", key="elevator_music",         default=true,  tooltip="Enable/disable elevator music logic." },
-	{ section="AI",       label="Nav Paths",     type="remote", key="ai_paths",               default=false, tooltip="Show AI navigation/path debug." },
+        { section="Monsters", label="Vision Cones", type="direct", remoteName="MonsterDebugEvent", default=false, tooltip="Show/hide monster vision cones." },
+        { section="Elevator", label="Show Sensors", type="remote", key="elevator_sensors",       default=false, tooltip="Paint doorway & cabin sensors (server-side)." },
+        { section="Elevator", label="Music",         type="remote", key="elevator_music",         default=true,  tooltip="Enable/disable elevator music logic." },
+        { section="AI",       label="Nav Paths",     type="remote", key="ai_paths",               default=false, tooltip="Show AI navigation/path debug." },
+        { section="Players",  label="Player Colliders", type="remote", key="player_colliders",    default=false, tooltip="Show player collision boxes." },
 }
 
 ----------------------------------------------------------------------

--- a/places/game/src/StarterPlayer/StarterPlayerScripts/PlayerColliderDebug.client.lua
+++ b/places/game/src/StarterPlayer/StarterPlayerScripts/PlayerColliderDebug.client.lua
@@ -1,0 +1,89 @@
+-- PlayerColliderDebug.client.lua
+-- Visualizes player collision boxes via SelectionBox instances.
+
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local Maid = require(ReplicatedStorage.Modules.combinedFunctions.Maid)
+
+local eventsFolder = ReplicatedStorage:FindFirstChild("DebugEvents")
+local flagsFolder = ReplicatedStorage:FindFirstChild("DebugFlags")
+
+local debugEvent = eventsFolder and eventsFolder:FindFirstChild("PlayerColliders")
+local flagValue = flagsFolder and flagsFolder:FindFirstChild("PlayerColliders")
+
+local activeMaid = Maid.new()
+
+local function addBoxes(character, charMaid)
+        local function attach(inst)
+                if inst:IsA("BasePart") then
+                        local box = Instance.new("SelectionBox")
+                        box.Adornee = inst
+                        box.LineThickness = 0.05
+                        box.SurfaceTransparency = 1
+                        box.Parent = inst
+                        charMaid:GiveInstance(box)
+                end
+        end
+
+        for _, inst in ipairs(character:GetDescendants()) do
+                attach(inst)
+        end
+
+        charMaid:GiveSignal(character.DescendantAdded, attach)
+end
+
+local function watchPlayer(player)
+        local pMaid = Maid.new()
+        activeMaid:GiveCleanup(tostring(player.UserId), function()
+                pMaid:Destroy()
+        end)
+
+        local function onCharacter(char)
+                pMaid:EndAllTasks()
+                local cMaid = Maid.new()
+                pMaid:GiveCleanup("char", function()
+                        cMaid:Destroy()
+                end)
+                cMaid:BindToInstance(char)
+                addBoxes(char, cMaid)
+        end
+
+        if player.Character then
+                onCharacter(player.Character)
+        end
+        pMaid:GiveSignal(player.CharacterAdded, onCharacter)
+end
+
+local function enable()
+        for _, plr in ipairs(Players:GetPlayers()) do
+                watchPlayer(plr)
+        end
+        activeMaid:GiveSignal(Players.PlayerAdded, watchPlayer)
+        activeMaid:GiveSignal(Players.PlayerRemoving, function(plr)
+                activeMaid:EndTaskByTaskId(tostring(plr.UserId))
+        end)
+end
+
+local function disable()
+        activeMaid:EndAllTasks()
+end
+
+local function setEnabled(v)
+        disable()
+        if v then
+                enable()
+        end
+end
+
+if debugEvent then
+        debugEvent.Event:Connect(setEnabled)
+end
+
+if flagValue and flagValue:IsA("BoolValue") then
+        setEnabled(flagValue.Value)
+        flagValue.Changed:Connect(function()
+                setEnabled(flagValue.Value)
+        end)
+end
+


### PR DESCRIPTION
## Summary
- add Player Colliders toggle to debug menu
- add client script to draw selection boxes on player character parts controlled by debug flag

## Testing
- `rojo build places/game/default.project.json` *(fails: command not found)*
- `cargo install --locked rojo@7.5.1` *(fails: spurious network error 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bbdd7e8f9c8333915ce07e4880e3d3